### PR TITLE
Switch to icalendar from pycal

### DIFF
--- a/calmerge.py
+++ b/calmerge.py
@@ -36,7 +36,6 @@ from configparser import ConfigParser
 # TODO
 # - check moved events from all to wrk and "rename" - currently just delete
 #   "all" event to regenerate wrk one
-# - use icalendar module instead of self-woven parser for ics files
 
 # HOWTO
 # turn off the "all" calendar from sync'ing


### PR DESCRIPTION
When importing events with a description pycal doesn't seemt to properly
unescape the longer description field, leading to `\,\n\` in the
description on line breaks.

With icalendar the parsing of the ics file is more complete and the
description gets unescaped automatically. Also the times are decoded at
once.